### PR TITLE
Update co@4.0.0

### DIFF
--- a/examples/confirm.js
+++ b/examples/confirm.js
@@ -7,4 +7,4 @@ co(function *(){
   var ok = yield confirm('are you sure? ');
   console.log('answer: %s', ok);
   process.stdin.pause();
-})();
+});

--- a/examples/password.js
+++ b/examples/password.js
@@ -10,4 +10,4 @@ co(function *(){
   console.log('user: %s', user);
   console.log('pass: %s', pass);
   process.stdin.pause();
-})();
+});

--- a/examples/prompt.js
+++ b/examples/prompt.js
@@ -13,4 +13,4 @@ co(function *(){
   console.log(desc);
 
   process.stdin.pause();
-})();
+});

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "co"
   ],
   "devDependencies": {
-    "should": "~1.2.2",
+    "co": "^4.0.0",
     "mocha": "~1.10.0",
-    "co": "2.1.0"
+    "should": "~1.2.2"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
@tj can you publish a new minor version so that the `No repository field` message is gone from the npm output?
