### PR TITLE
Added a default value parameter to prompt

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function prompt(msg){
     process.stdout.write(msg);
     process.stdin.setEncoding('utf8');
     process.stdin.once('data', function(val){
-      done(null, val.trim());
+      done(null, (val.length <= 1 && defaultVal) ? defaultVal : val.trim());
     }).resume();
   }
 }


### PR DESCRIPTION
Addresses Issue #5
## Without specified default

`yield prompt('first name: ');`
## With specified default

`yield prompt('first name: ', 'John');`
