### PR TITLE
Allow for backspacing when entering a password

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,8 +87,14 @@ exports.password = function(msg, mask){
         process.exit();
       }
 
-      process.stdout.write(mask);
-      buf += c;
+      if (key && key.name === 'backspace') {
+          if (buf.length > 0) {
+              buf = buf.slice(0, -1);
+          }
+      } else {
+          process.stdout.write(mask);
+          buf += c;
+      }
     }).resume();
   }
 };


### PR DESCRIPTION
Before: When typing into a prompt.password, if you were to make a typo and press delete to on your keyboard so that you could change it, it would just keep adding to the buffer as well as the process.stdout.

After: The backspace keypress is caught, trimming the final character off the keypress, as well as not including it in the buffer.
